### PR TITLE
Clicking on a value copies it to the clipboard

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,7 @@
 /*
  * IP Finder gnome extension
  * https://github.com/LinxGem33/IP-Finder
- * 
+ *
  * Copyright (C) 2017 LinxGem33 (Andy C)
  *
  * This file is part of IP Finder gnome extension.
@@ -17,7 +17,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with IP Finder gnome extension.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  */
 
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
@@ -189,8 +189,14 @@ const IPMenu = new Lang.Class({ //menu bar item
       let ipInfoRow = new St.BoxLayout();
       ipInfoBox.add_actor(ipInfoRow);
       ipInfoRow.add_actor(new St.Label({style_class: 'ip-info-key', text: _(key) + ': '}));
-      this['_' + key] = new St.Label({style_class: 'ip-info-value', text: DEFAULT_DATA[key]});
-      ipInfoRow.add_actor(this['_' + key]);
+      let label = new St.Button({child: new St.Label({style_class: 'ip-info-value', text: DEFAULT_DATA[key]})});
+
+      label.connect('button-press-event', function() {
+        label.child.text = "Test";
+      });
+
+      ipInfoRow.add_actor(label);
+      this['_' + key] = label;
     });
 
     let _appSys = Shell.AppSystem.get_default();
@@ -296,7 +302,7 @@ const IPMenu = new Lang.Class({ //menu bar item
             self._label.text = self._compactMode ? '' : ipData.ip;
 
             Object.keys(ipData).map(function(key) {
-              this['_' + key].text = ipData[key];
+              this['_' + key].child.text = ipData[key];
             });
 
             self._icon.gicon = Gio.icon_new_for_string(Me.path + '/icons/flags/' + ipData.country + '.png');

--- a/extension.js
+++ b/extension.js
@@ -192,14 +192,13 @@ const IPMenu = new Lang.Class({ //menu bar item
       let ipInfoRow = new St.BoxLayout();
       ipInfoBox.add_actor(ipInfoRow);
       ipInfoRow.add_actor(new St.Label({style_class: 'ip-info-key', text: _(key) + ': '}));
-      let label = new St.Button({child: new St.Label({style_class: 'ip-info-value', text: DEFAULT_DATA[key]})});
 
-      label.connect('button-press-event', function() {
-        Clipboard.set_text(CLIPBOARD_TYPE, label.child.text);
+      let dataLabelBtn = new St.Button({child: new St.Label({style_class: 'ip-info-value', text: DEFAULT_DATA[key]})});
+      dataLabelBtn.connect('button-press-event', function() {
+        Clipboard.set_text(CLIPBOARD_TYPE, dataLabelBtn.child.text);
       });
-
-      ipInfoRow.add_actor(label);
-      this['_' + key] = label;
+      ipInfoRow.add_actor(dataLabelBtn);
+      this['_' + key] = dataLabelBtn;
     });
 
     let _appSys = Shell.AppSystem.get_default();

--- a/extension.js
+++ b/extension.js
@@ -47,6 +47,9 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 const Soup = imports.gi.Soup;
 
+const Clipboard = St.Clipboard.get_default();
+const CLIPBOARD_TYPE = St.ClipboardType.CLIPBOARD;
+
 const Metadata = Me.metadata;
 
 const ICON_SIZE = 16;
@@ -192,7 +195,7 @@ const IPMenu = new Lang.Class({ //menu bar item
       let label = new St.Button({child: new St.Label({style_class: 'ip-info-value', text: DEFAULT_DATA[key]})});
 
       label.connect('button-press-event', function() {
-        label.child.text = "Test";
+        Clipboard.set_text(CLIPBOARD_TYPE, label.child.text);
       });
 
       ipInfoRow.add_actor(label);


### PR DESCRIPTION
With this change clicking on a value, for example the ip, copies it to the clipboard.
This change was made because the ability to see my ip in only 1 click doesn't make sense if i can't copy it.

I didn't add an animation to indicate the data was copied successfully to the clipboard, since this is the first time i look at the source code of a gnome extension.
If there are any problems please let me know and i will do my best to fix it.